### PR TITLE
Add the right comparator sign for bash

### DIFF
--- a/install-kaldi.sh
+++ b/install-kaldi.sh
@@ -1,6 +1,6 @@
 KALDI_DIRECTORY=/usr/share/kaldi
 AVAILABLE_CORES=$(getconf _NPROCESSORS_ONLN)
-if [ $AVAILABLE_CORES > 1 ]; then
+if [ $AVAILABLE_CORES -gt 1 ]; then
   AVAILABLE_CORES=$(expr $AVAILABLE_CORES / 2)
 fi
 


### PR DESCRIPTION
This is to solve the problem encountered by users with 1 core ( probably VM users ; ) :bug: