### PR TITLE
Travis CI: Try running on Python 3.5, 3.6, and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: xenial
-sudo: required
 language: python
+python:
+    - 3.5
+    - 3.6
+    - 3.7
 virtualenv:
     system_site_packages: true
 services:
@@ -25,7 +28,7 @@ before_script:
     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-    - python3 -m pytest --capture=sys
+    - python -m pytest --capture=sys
 notifications:
     on_success: change
     on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Related to #91 ?

[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)