### PR TITLE
Travis CI: Try using Services: XVFB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 dist: xenial
-sudo: required
 language: python
 virtualenv:
     system_site_packages: true
 services:
     - mysql
-addons:
-    apt:
-        packages:
-            - xvfb
+    - xvfb
 cache:
     directories:
         - /usr/share/dragonfire
@@ -17,8 +13,6 @@ before_install:
 install:
     - sudo ./install-dev.sh --no-model
     - sudo pip3 install pytest-faulthandler
-    - export DISPLAY=':99.0'
-    - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 before_script:
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics


### PR DESCRIPTION
Travis is trying to make it easier...
https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services-xvfb

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"