### PR TITLE
use `PIP_NO_CACHE_DIR=off` in docker env from dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Use an official Python runtime as a parent image
 FROM ubuntu:18.04
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED 1 \
+    PIP_NO_CACHE_DIR=off
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Maintainer


### PR DESCRIPTION
using `PIP_NO_CACHE_DIR=off` in docker env ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>